### PR TITLE
applespi: Document ACPI methods

### DIFF
--- a/applespi.c
+++ b/applespi.c
@@ -1,3 +1,21 @@
+/**
+ * The keyboard and touchpad controller on the MacBook8,1, MacBook9,1 and
+ * MacBookPro12,1 can be driven either by USB or SPI. However the USB pins
+ * are only connected on the MacBookPro12,1, all others need this driver.
+ * The interface is selected using ACPI methods:
+ *
+ * * UIEN ("USB Interface Enable"): If invoked with argument 1, disables SPI
+ *   and enables USB. If invoked with argument 0, disables USB.
+ * * UIST ("USB Interface Status"): Returns 1 if USB is enabled, 0 otherwise.
+ * * SIEN ("SPI Interface Enable"): If invoked with argument 1, disables USB
+ *   and enables SPI. If invoked with argument 0, disables SPI.
+ * * SIST ("SPI Interface Status"): Returns 1 if SPI is enabled, 0 otherwise.
+ * * ISOL: Resets the four GPIO pins used for SPI. Intended to be invoked with
+ *   argument 0, then once more with argument 1.
+ *
+ * UIEN and UIST are only provided on the MacBookPro12,1.
+ */
+
 #define pr_fmt(fmt) "applespi: " fmt
 
 #include <linux/platform_device.h>


### PR DESCRIPTION
Regarding power consumption, you might be looking in the wrong place if you're searching for the interrupt in `/proc/interrupts`. The DSDT shows that GPE 0x1C sends a device notification, so you need to look at `/sys/firmware/acpi/interrupts/gpe1C` and see under which conditions it increases. Is the GPE only used for wake from system sleep or is it used for power management? If the latter, perhaps you need to stop polling after a period of inactivity and power down the device with SIEN(0), then wait for the device to send a notification and power it up with SIEN(1). You can call SIEN using `acpi_execute_simple_method()`, see l1k/linux@65f56e6c84462335e19b780e5d3140b769d97963 for an example. To make use of the GPE, call `acpi_install_notify_handler()` and `acpi_enable_gpe()`, see `drivers/platform/x86/apple-gmux.c` for an example.

As to patching the DSDT, I think this should be avoided if possible. I believe the macOS driver retrieves the required configuration data from the I/O Kit registry, which in turn is filled with values from the _DSM in ACPI. I've recently implemented retrieval of Apple device properties from EFI, see https://github.com/l1k/linux/commits/apple_properties_v1 . Could you test that branch on your MacBook8,1, boot with "dump_apple_properties" and attach the dmesg output to bugzilla? Perhaps the SPI EFI driver sends some device properties that might be of use.

If it doesn't, we could make the data in the _DSM available as device properties as well so that they can be accessed using the API in `<linux/property.h>` (see l1k/linux@8743c01825c3d16f812acec7525e5c87f4eed37a for an example). That would require some changes to the ACPI subsystem to fetch the properties from Apple's nonstandard _DSM instead of the standard _DSD. Would the properties in the _DSM enable you to avoid patching the DSDT?