### PR TITLE
applespi: Re-enable SPI on resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ What works:
 * Basic touchpad functionality (even right click, handled by libinput)
 * MT touchpad functionality (two finger scroll, probably others)
 * Interrupts!
+* Suspend / resume
 
 What doesn't work:
 ------------------
 * Key rollover (properly)
 * FN keys (simple enough)
-* Suspend / resume
 * Wakeup on keypress / touchpad
  
 Known bugs:


### PR DESCRIPTION
The firmware calls the SIEN ACPI method on boot to enable the
keyboard and trackpad. However, after resuming from sleep, the SPI
interface is disabled and we must call SIEN(1) to enable it.

Signed-off-by: Cameron Gutman aicommander@gmail.com
