### PR TITLE
applespi: Change the default for iso-layout to disabled.

### DIFF
--- a/applespi.c
+++ b/applespi.c
@@ -52,7 +52,7 @@ module_param(fnmode, uint, 0644);
 MODULE_PARM_DESC(fnmode, "Mode of fn key on Apple keyboards (0 = disabled, "
 		"[1] = fkeyslast, 2 = fkeysfirst)");
 
-static unsigned int iso_layout = 1;
+static unsigned int iso_layout = 0;
 module_param(iso_layout, uint, 0644);
 MODULE_PARM_DESC(iso_layout, "Enable/Disable hardcoded ISO-layout of the keyboard. "
 		"(0 = disabled, [1] = enabled)");


### PR DESCRIPTION
Unlike the hid-apple driver, we don't have any idea whether the current
keyboard is using the iso-layout or not. This means that the iso_layout
has subtly different semantics here than on hid-apple (from which this
was copied): rather than just allowing for disabling of the iso-layout
on iso keyboards, the flag here determines which layout is used on all
keyboards. Therefore the flag's default should reflect the most common
keyboard type, which is not iso.