### PR TITLE
applespi: Convert #ifdef'd debug logs to normal debug logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Touchpad:
 ---------
 The touchpad protocol is the same as the bcm5974 driver. Perhaps there is a nice way of utilizing it? For now, bits of code have just been copy and pasted.
 
+Debugging:
+----------
+The `debug` module parameter can be used to turn debugging output on (and off) dynamically, and can be set in all the usual ways (e.g. via kernel command-line (`applespi.debug=0x1`), via sysfs (`echo 0x10000 | sudo tee /sys/module/applespi/parameters/debug`), etc.).
+
+Some useful values are (since the value is a bitmask, these can be combined):
+* 0x10000 - determine touchpad values range
+* 0x1     - turn on logging of touchpad initialization packets
+* 0x6     - turn on logging of backlight and caps-lock-led packets
+
 Some useful threads:
 --------------------
 * https://bugzilla.kernel.org/show_bug.cgi?id=108331


### PR DESCRIPTION
I'm submitting this mainly for discussion rather than for actual merging. The biggest problem I see with this as it stands is that it's hard to enable debugging of just some packets, and enabling all results in a _huge_ amount of logging in the kernel log, swamping pretty much everything else (mostly due to the touchpad events). E.g. while it's possible to enable logging of just the touchpad init messages, that's only because they are currently only ones using the `applespi_sync_*` functions, i.e. if something else starts using them in the future then that new stuff would get logged to when enabling logging for these functions. And enabling logging of received events does so for both keyboard and touchpad events. Also, as I've discovered recently, it doesn't seem possible to enable logging of just some functions via the kernel command line (the docs indicate it should be, but after debugging the dynamic-debuging code in the kernel I've come to the conclusion that just doesn't seem to be the case).

I think ideally we'd want a way to be able to (dynamically) enable/disable logging of messages based on type: init, keyboard events, touchpad events, backlight commands, etc. But AFAICT this can't be done cleanly with the dynamic-debug framework alone. So, maybe we need our own `debug` module parameter to control logging of messages.

Comments, ideas, thoughts?