### PR TITLE
Updated required module for MacBook8,1 (2015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Very simple, work in progress input driver for the SPI keyboard / trackpad found
 
 Using it:
 ---------
-If you're on a MacBook8,1 (2015) you may need the `irqpoll` kernel parameter. To get this driver to work on all other MacBooks and MacBook Pros, you'll need to boot the kernel with `intremap=nosid` if you're running a kernel before 4.11. In all cases make sure you don't have `noapic` in your kernel options.
+If you're on a MacBook8,1 (2015) you will need to use `spi_pxa2xx_pci` instead of `intel_lpss_pci`. To get this driver to work on all other MacBooks and MacBook Pros, you'll need to boot the kernel with `intremap=nosid` if you're running a kernel before 4.11. In all cases make sure you don't have `noapic` in your kernel options.
 
 On the 2015 MacBook you need to (re)compile your kernel with `CONFIG_X86_INTEL_LPSS=n` if running a kernel before 4.14. On all kernels you need ensure the `spi_pxa2xx_platform` module is loaded (if you don't have that module, rebuild your kernel with `CONFIG_SPI_PXA2XX=m`).
 
@@ -10,13 +10,23 @@ On all other MacBook's and MacBook Pros you need to make sure both the `spi_pxa2
 
 DKMS module (Debian & co):
 --------------------------
-As root, do the following:
+As root, do the following (most MacBooks):
 ```
 apt install dkms
 git clone https://github.com/cb22/macbook12-spi-driver.git /usr/src/applespi-0.1
 dkms install -m applespi -v 0.1
 
 echo -e "\n# applespi\napplespi\nintel_lpss_pci\nspi_pxa2xx_platform" >> /etc/initramfs-tools/modules
+update-initramfs -u
+```
+
+If you're on a MacBook8,1 (2015):
+```
+apt install dkms
+git clone https://github.com/cb22/macbook12-spi-driver.git /usr/src/applespi-0.1
+dkms install -m applespi -v 0.1
+
+echo -e "\n# applespi\napplespi\nspi_pxa2xx_platform\nspi_pxa2xx_pci" >> /etc/initramfs-tools/modules
 update-initramfs -u
 ```
 


### PR DESCRIPTION
Using spi_pxa2xx_pci removes the need for irqpoll and fixes initramfs https://github.com/cb22/macbook12-spi-driver/issues/50